### PR TITLE
fix: return configuration

### DIFF
--- a/src/bucket.tf
+++ b/src/bucket.tf
@@ -4,7 +4,7 @@
 #}
 
 resource "aws_s3_bucket" "lambda_artifacts_bucket" {
-  bucket        = var.lambda_artifacts_bucket_name
+  bucket        = "${var.projectName}-lambda-artifacts-bucket"
   force_destroy = true
 
   tags = merge(var.tags, {


### PR DESCRIPTION
This pull request makes a small change to the S3 bucket resource in `src/bucket.tf`. The bucket name is now constructed using the `projectName` variable to ensure consistency and avoid naming conflicts.